### PR TITLE
compilation Error with gcc5 fixed

### DIFF
--- a/pcsc-ctapi-wrapper.c
+++ b/pcsc-ctapi-wrapper.c
@@ -654,7 +654,7 @@ static IS8 PerformVerification(IU16 ctn, IU8 *dad, IU8 *sad, IU16 lenc, IU8 *com
 	
 	// Performing verification:
 	nBytesReturned = 0;
-	nResult = SCardControl(hCard, dwControlCode, pPVS, sizeof(PIN_VERIFY_STRUCTURE)-sizeof(pPVS->abData)+nPinApduLength,
+	nResult = SCardControl(hCard, dwControlCode, pPVS, sizeof(PIN_VERIFY_STRUCTURE)-sizeof(&pPVS->abData)+nPinApduLength,
 			aOutput, sizeof(aOutput), &nBytesReturned);
 	if (nResult != SCARD_S_SUCCESS)
 	{


### PR DESCRIPTION
change Line 657: use of '&' in sizeof Func

Tested with success on Ubuntu 16.04 LTS with gcc 5 and
OS X 10.10 with clang 600.0.57 and chipdrive SPR 532 using PC Keyboard
for PIN Input in Hibiscus

Some Compilation Warnigs still remain.

TODO: Fix Warnings
