### PR TITLE
workaround compile error by not using C11 standard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 DESTDIR = /usr/local/lib
-CFLAGS = -O2 -Wall -I /usr/include/PCSC/ -fPIC -D_REENTRANT -D USE_CTN_BASE0
+CFLAGS = -O2 -std=gnu90 -Wall -I /usr/include/PCSC/ -fPIC -D_REENTRANT -D USE_CTN_BASE0
 
 # chose from
 #   USE_PORT_BASE1 (Matrica: Moneyplex)


### PR DESCRIPTION
default gcc compiler version would be "gnu11", which is to "strict" for the compile time.

The whole wrapper should rather be rewritten, than tweaking it to compile....
